### PR TITLE
added adjustments to be made while installing dependencies on a mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ DATABASE_PORT
 
 5. Migrate models:
 `python manage.py migrate`
+
+### For mac users, please make the following adjustments before installing the dependencies
+
+1. Install `Rust` (use `brew`)
+2. Install `libmagic` (use `brew`)
+3. Update `pip` to the latest version


### PR DESCRIPTION
When installing dependencies on a mac, we get errors like `ImportError: failed to find libmagic`. This pull requests updates the readme to include required adjustments needed on a mac to prevent the errors.